### PR TITLE
Improve GH cache, remove hie yaml, remove -exe from executable name

### DIFF
--- a/aoc.hsfiles
+++ b/aoc.hsfiles
@@ -34,7 +34,7 @@ library:
   source-dirs: src
 
 executables:
-  {{name}}-exe:
+  {{name}}:
     main:                Main.hs
     source-dirs:         app
     ghc-options:
@@ -550,54 +550,63 @@ spec = describe "Day N" $ do
   xit "solve the puzzle" $ do
      input <- T.readFile "resources/inputN"
      logic input `shouldBe` Answer
-
 {-# START_FILE README.md #-}
 # {{name}}
 
 ## How to build and run locally
 
-The project uses the [Haskell tool stack](https://docs.haskellstack.org/en/stable/README/).
+The project uses the [Haskell tool stack](https://docs.haskellstack.org/en/stable/README/). The recommended way to install stack is by using [ghcup](https://www.haskell.org/ghcup/).
+It's also possible to use [the nix package manager](https://nixos.org/), but this project does not provide a nix configuration file.
 
-Assuming `stack` is installed in the system, the project can be build by running
+Assuming `stack` is installed in the system, to **build** the project use
 ```
 stack build
 ```
-To build and also run the tests, run
+To **build and run the tests**, run
 ```
 stack test
 ```
-which is equivalent to
+or equivalently
 ```
 stack build --test
 ```
-To run with test coverage
+For **faster feedback loop** during development, it's possible to run tests continuously on every file change:
+```
+stack test --fast --file-watch
+```
+To run tests with **test coverage** instrumentation,
 ```
 stack test --coverage
 ```
 which generates a textual and HTML report.
 
-To run the executable,
+Note: Tests are run in the CI and test coverage reports are automatically uploaded to codecov.
+
+To **run** the executable via slack,
 ```
-stack exec {{name}}-exe
+stack exec {{name}}
 ```
 or passing arguments
 ```
-stack exec {{name}}-exe -- -d <day> -f <filename> 
+stack exec {{name}} -- -d <day> -f <filename>
 ```
 
-For faster feedback loop,
+To **install** the executable under `~/.local/bin`,
 ```
-stack test --fast --file-watch
+stack install
 ```
-To run `ghci` (with a version compatible with the resolver) run
+and the executable can be run with `{{name}}` assuming `~/.local/bin` is in the `$PATH` variable.
+
+To run a version of **ghci** compatible with the resolver
 ```
 stack ghci
 ```
-For more information, refer to the `stack` official docs.
+For more information about how to use `stack`, refer to the [official docs](https://docs.haskellstack.org/en/stable/).
 
+This projects uses [optparse-applicative](https://hackage.haskell.org/package/optparse-applicative) to implement command-line arguments parsing. Optparse-applicative automatically generates an helper from code. It's recommended to use the generated helper to explore all the available CLI options.
 {-# START_FILE .github/workflows/ci.yml #-}
 {{=<% %>=}}
-name: CI
+name: Compile and run tests
 
 on:
   push:
@@ -623,16 +632,28 @@ jobs:
 
     steps:
 
-    - name: Checkout repo 
+    - name: Checkout repo
       uses: actions/checkout@v4
 
-    - name: Restore from cache
+    - name: Cache stack installation
       uses: actions/cache@v4
       with:
         path: |
-          ~/.stack
-          ~/.ghcup
-        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-stack-${{ matrix.stack }}-${{ hashFiles('stack.yaml') }}
+          ~/.stack/build-plan
+          ~/.stack/indices
+          ~/.stack/snapshots
+          ~/.stack/global-project/.stack-work/install
+        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-stack-${{ matrix.stack }}-${{ hashFiles('stack.yaml', 'stack.yaml.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-ghc-${{ matrix.ghc }}-stack-${{ matrix.stack }}-
+
+    - name: Cache GHC installation
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.ghcup/ghc/${{ matrix.ghc }}
+          ~/.ghcup/bin/stack-${{ matrix.stack }}
+        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-stack-${{ matrix.stack }}
 
     - name: Setup Haskell Stack
       uses: haskell-actions/setup@v2
@@ -673,22 +694,6 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 <%={{ }}=%>
-{-# START_FILE hie.yaml #-}
-cradle:
-  stack:
-    - path: "./src"
-      component: "{{name}}:lib"
-
-    - path: "./app/Main.hs"
-      component: "{{name}}:exe:{{name}}-exe"
-
-    - path: "./app/Paths_{{name}}.hs"
-      component: "{{name}}:exe:{{name}}-exe"
-
-    - path: "./test"
-      component: "{{name}}:test:{{name}}-test"
-
-
 {-# START_FILE .gitignore #-}
 # Stack
 .stack-work/

--- a/cli-template.hsfiles
+++ b/cli-template.hsfiles
@@ -28,7 +28,7 @@ library:
   source-dirs: src
 
 executables:
-  {{name}}-exe:
+  {{name}}:
     main:                Main.hs
     source-dirs:         app
     ghc-options:
@@ -167,48 +167,58 @@ parseArgs = execParserPure preferences parserInfo where
 
 ## How to build and run locally
 
-The project uses the [Haskell tool stack](https://docs.haskellstack.org/en/stable/README/).
+The project uses the [Haskell tool stack](https://docs.haskellstack.org/en/stable/README/). The recommended way to install stack is by using [ghcup](https://www.haskell.org/ghcup/).
+It's also possible to use [the nix package manager](https://nixos.org/), but this project does not provide a nix configuration file.
 
-Assuming `stack` is installed in the system, the project can be build by running
+Assuming `stack` is installed in the system, to **build** the project use
 ```
 stack build
 ```
-To build and also run the tests, run
+To **build and run the tests**, run
 ```
 stack test
 ```
-which is equivalent to
+or equivalently
 ```
 stack build --test
 ```
-To run with test coverage
+For **faster feedback loop** during development, it's possible to run tests continuously on every file change:
+```
+stack test --fast --file-watch
+```
+To run tests with **test coverage** instrumentation,
 ```
 stack test --coverage
 ```
 which generates a textual and HTML report.
 
-To run the executable,
+Note: Tests are run in the CI and test coverage reports are automatically uploaded to codecov.
+
+To **run** the executable via slack,
 ```
-stack exec {{name}}-exe
+stack exec {{name}}
 ```
 or passing arguments
 ```
-stack exec {{name}}-exe -- -v doctor
+stack exec {{name}} -- -v doctor
 ```
 
-For faster feedback loop,
+To **install** the executable under `~/.local/bin`,
 ```
-stack test --fast --file-watch
+stack install
 ```
-To run `ghci` (with a version compatible with the resolver) run
+and the executable can be run with `{{name}}` assuming `~/.local/bin` is in the `$PATH` variable.
+
+To run a version of **ghci** compatible with the resolver
 ```
 stack ghci
 ```
-For more information, refer to the `stack` official docs.
+For more information about how to use `stack`, refer to the [official docs](https://docs.haskellstack.org/en/stable/).
 
+This projects uses [optparse-applicative](https://hackage.haskell.org/package/optparse-applicative) to implement command-line arguments parsing. Optparse-applicative automatically generates an helper from code. It's recommended to use the generated helper to explore all the available CLI options.
 {-# START_FILE .github/workflows/ci.yml #-}
 {{=<% %>=}}
-name: CI
+name: Compile and run tests
 
 on:
   push:
@@ -234,16 +244,28 @@ jobs:
 
     steps:
 
-    - name: Checkout repo 
+    - name: Checkout repo
       uses: actions/checkout@v4
 
-    - name: Restore from cache
+    - name: Cache stack installation
       uses: actions/cache@v4
       with:
         path: |
-          ~/.stack
-          ~/.ghcup
-        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-stack-${{ matrix.stack }}-${{ hashFiles('stack.yaml') }}
+          ~/.stack/build-plan
+          ~/.stack/indices
+          ~/.stack/snapshots
+          ~/.stack/global-project/.stack-work/install
+        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-stack-${{ matrix.stack }}-${{ hashFiles('stack.yaml', 'stack.yaml.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-ghc-${{ matrix.ghc }}-stack-${{ matrix.stack }}-
+
+    - name: Cache GHC installation
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.ghcup/ghc/${{ matrix.ghc }}
+          ~/.ghcup/bin/stack-${{ matrix.stack }}
+        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-stack-${{ matrix.stack }}
 
     - name: Setup Haskell Stack
       uses: haskell-actions/setup@v2
@@ -284,22 +306,6 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 <%={{ }}=%>
-{-# START_FILE hie.yaml #-}
-cradle:
-  stack:
-    - path: "./src"
-      component: "{{name}}:lib"
-
-    - path: "./app/Main.hs"
-      component: "{{name}}:exe:{{name}}-exe"
-
-    - path: "./app/Paths_{{name}}.hs"
-      component: "{{name}}:exe:{{name}}-exe"
-
-    - path: "./test"
-      component: "{{name}}:test:{{name}}-test"
-
-
 {-# START_FILE .gitignore #-}
 # Stack
 .stack-work/

--- a/servant-server-template.hsfiles
+++ b/servant-server-template.hsfiles
@@ -27,7 +27,7 @@ library:
   source-dirs: src
 
 executables:
-  {{name}}-exe:
+  {{name}}:
     main:                Main.hs
     source-dirs:         app
     ghc-options:
@@ -131,49 +131,63 @@ import Server
 
 main :: IO ()
 main = startServer
-
 {-# START_FILE README.md #-}
 # {{name}}
 
 ## How to build and run locally
 
-The project uses the [Haskell tool stack](https://docs.haskellstack.org/en/stable/README/).
+The project uses the [Haskell tool stack](https://docs.haskellstack.org/en/stable/README/). The recommended way to install stack is by using [ghcup](https://www.haskell.org/ghcup/).
+It's also possible to use [the nix package manager](https://nixos.org/), but this project does not provide a nix configuration file.
 
-Assuming `stack` is installed in the system, the project can be build by running
+Assuming `stack` is installed in the system, to **build** the project use
 ```
 stack build
 ```
-To build and also run the tests, run
+To **build and run the tests**, run
 ```
 stack test
 ```
-which is equivalent to
+or equivalently
 ```
 stack build --test
 ```
-To run with test coverage
+For **faster feedback loop** during development, it's possible to run tests continuously on every file change:
+```
+stack test --fast --file-watch
+```
+To run tests with **test coverage** instrumentation,
 ```
 stack test --coverage
 ```
 which generates a textual and HTML report.
 
-To run the executable,
+Note: Tests are run in the CI and test coverage reports are automatically uploaded to codecov.
+
+To **run** the executable via slack,
 ```
-stack exec {{name}}-exe
+stack exec {{name}}
 ```
-For faster feedback loop,
+or passing arguments
 ```
-stack test --fast --file-watch
+stack exec {{name}} -- -v doctor
 ```
-To run `ghci` (with a version compatible with the resolver) run
+
+To **install** the executable under `~/.local/bin`,
+```
+stack install
+```
+and the executable can be run with `{{name}}` assuming `~/.local/bin` is in the `$PATH` variable.
+
+To run a version of **ghci** compatible with the resolver
 ```
 stack ghci
 ```
-For more information, refer to the `stack` official docs.
+For more information about how to use `stack`, refer to the [official docs](https://docs.haskellstack.org/en/stable/).
 
+This projects uses [optparse-applicative](https://hackage.haskell.org/package/optparse-applicative) to implement command-line arguments parsing. Optparse-applicative automatically generates an helper from code. It's recommended to use the generated helper to explore all the available CLI options.
 {-# START_FILE .github/workflows/ci.yml #-}
 {{=<% %>=}}
-name: CI
+name: Compile and run tests
 
 on:
   push:
@@ -199,16 +213,28 @@ jobs:
 
     steps:
 
-    - name: Checkout repo 
+    - name: Checkout repo
       uses: actions/checkout@v4
 
-    - name: Restore from cache
+    - name: Cache stack installation
       uses: actions/cache@v4
       with:
         path: |
-          ~/.stack
-          ~/.ghcup
-        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-stack-${{ matrix.stack }}-${{ hashFiles('stack.yaml') }}
+          ~/.stack/build-plan
+          ~/.stack/indices
+          ~/.stack/snapshots
+          ~/.stack/global-project/.stack-work/install
+        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-stack-${{ matrix.stack }}-${{ hashFiles('stack.yaml', 'stack.yaml.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-ghc-${{ matrix.ghc }}-stack-${{ matrix.stack }}-
+
+    - name: Cache GHC installation
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.ghcup/ghc/${{ matrix.ghc }}
+          ~/.ghcup/bin/stack-${{ matrix.stack }}
+        key: ${{ runner.os }}-ghc-${{ matrix.ghc }}-stack-${{ matrix.stack }}
 
     - name: Setup Haskell Stack
       uses: haskell-actions/setup@v2
@@ -249,22 +275,6 @@ jobs:
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 <%={{ }}=%>
-{-# START_FILE hie.yaml #-}
-cradle:
-  stack:
-    - path: "./src"
-      component: "{{name}}:lib"
-
-    - path: "./app/Main.hs"
-      component: "{{name}}:exe:{{name}}-exe"
-
-    - path: "./app/Paths_{{name}}.hs"
-      component: "{{name}}:exe:{{name}}-exe"
-
-    - path: "./test"
-      component: "{{name}}:test:{{name}}-test"
-
-
 {-# START_FILE .gitignore #-}
 # Stack
 .stack-work/


### PR DESCRIPTION
* Improve GH cache -> at the very least, now I'm using the hash of stack lock as part of the cache key, which should ensure better robustness. I'm sure there're countless improvements to be made (eg, avoid hardcoding ghc and stack versions? fix all sort of cache issues? publish artifacts? versioning? etc) 
* remove hie yaml -> these days, HLS seems to behave fine even without it 
* `-exe` in the executable name was copied from the original stack template, but when installing the executable is annoying to have to type also the `-exe` part. 
* updated the readme too, to reflect the new executable name and add few more commands