### PR TITLE
Fix readme of servant project

### DIFF
--- a/servant-server-template.hsfiles
+++ b/servant-server-template.hsfiles
@@ -193,7 +193,6 @@ stack ghci
 ```
 For more information about how to use `stack`, refer to the [official docs](https://docs.haskellstack.org/en/stable/).
 
-This projects uses [optparse-applicative](https://hackage.haskell.org/package/optparse-applicative) to implement command-line arguments parsing. Optparse-applicative automatically generates an helper from code. It's recommended to use the generated helper to explore all the available CLI options.
 {-# START_FILE .github/workflows/ci.yml #-}
 {{=<% %>=}}
 name: Compile and run tests


### PR DESCRIPTION
There's no optparse-applicative library (for now) in the generated servant app (although maybe in the future we might wanna use optparse applicative to pass params like default `port` etc)